### PR TITLE
Use env logger

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ name = "secret-share-combine"
 path = "src/bin/combine.rs"
 
 [dependencies]
+log = "0.3.8"
+env_logger = "0.4.3"
 shamirsecretsharing = "0.1"
 rand = "0.3"
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ name = "secret-share-combine"
 path = "src/bin/combine.rs"
 
 [dependencies]
-log = "0.3.8"
-env_logger = "0.4.3"
+log = "0.3"
+env_logger = "0.4"
 shamirsecretsharing = "0.1"
 rand = "0.3"
 libc = "0.2"

--- a/src/bin/combine.rs
+++ b/src/bin/combine.rs
@@ -33,8 +33,10 @@ fn main() {
     let mut shares_string = String::new();
     input_file
         .read_to_string(&mut shares_string)
-        .unwrap_or_else(|err| { error!("Error while reading stdin: {}", err);
-                                exit(1)});
+        .unwrap_or_else(|err| { 
+            error!("Error while reading stdin: {}", err);
+            exit(1)
+        });
     let lines = shares_string.lines().collect::<Vec<&str>>();
 
     // Decode the lines
@@ -97,11 +99,11 @@ fn main() {
         Ok(None) => {
             error!("Shares did not combine to a valid secret");
             exit(1);
-            },
+        },
         Err(err) => {
             error!("Error while combining shares: {}", err);
             exit(1);
-            },
+        },
     }
 
     // TODO(dsprenkels) In the case of binary data, output to stdout only if it is not a tty
@@ -113,8 +115,8 @@ fn main() {
                 .iter()
                 .map(|b| format!("{:02x}", b))
                 .collect::<String>();
-            info!("Warning: Invalid utf-8 text, some symbols may be lost!");
-            debug!("Note: The hex representation of the secret is '{}'.", hex);
+            warn!("Warning: Invalid utf-8 text, some symbols may be lost!");
+            info!("Note: The hex representation of the secret is '{}'.", hex);
             println!("Restored secret: '{}'", String::from_utf8_lossy(bytes));
         }
     }

--- a/src/bin/split.rs
+++ b/src/bin/split.rs
@@ -1,5 +1,8 @@
 #[macro_use]
 extern crate clap;
+extern crate env_logger;
+#[macro_use]
+extern crate log;
 extern crate rand;
 extern crate shamirsecretsharing_cli;
 extern crate shamirsecretsharing;
@@ -39,6 +42,9 @@ fn argparse<'a>() -> ArgMatches<'a> {
 }
 
 fn main() {
+    // Init env_logger
+    env_logger::init().expect("Failed to initiate logger");
+
     // Parse command line arguments
     let matches = argparse();
     let input_fn = matches.value_of("FILE");
@@ -57,18 +63,17 @@ fn main() {
     let mut input_file: Box<Read> = match input_fn {
         None | Some("-") => Box::new(std::io::stdin()),
         Some(input_fn) => {
-            Box::new(File::open(input_fn)
-            .unwrap_or_else(|err| {
-                eprintln!("Error while opening file '{}': {}", input_fn, err);
+            Box::new(File::open(input_fn).unwrap_or_else(|err| {
+                error!("Error while opening file '{}': {}", input_fn, err);
                 exit(1);
-            }))
+        }))
         }
     };
     // We are not able to use the normal API for variable length plaintexts, so we will have to
     // use the hazmat API and encrypt the file ourselves
     let key: [u8; KEY_SIZE] = random();
     let keyshares = create_keyshares(&key, count, treshold).unwrap_or_else(|err| {
-                                                                               eprintln!("{}", err);
+                                                                               error!("{}", err);
                                                                                exit(1);
                                                                            });
 

--- a/src/bin/split.rs
+++ b/src/bin/split.rs
@@ -66,7 +66,7 @@ fn main() {
             Box::new(File::open(input_fn).unwrap_or_else(|err| {
                 error!("Error while opening file '{}': {}", input_fn, err);
                 exit(1);
-        }))
+            }))
         }
     };
     // We are not able to use the normal API for variable length plaintexts, so we will have to


### PR DESCRIPTION
Replace `panic!` and `eprintln!` to use `error!` `info!` and `debug!` from `env_logger` - which by default all print to stderr. Closes #3