### PR TITLE
Add installation guide for homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ echo "Tyler Durden isn't real." | secret-share-split -n 4 -t 3 >shares.txt
 head -n 3 shares.txt | secret-share-combine
 ```
 
+Note that after this installation, you need to add Cargo's installation
+directory to your `$PATH` if you don't have it there yet.
+
 To uninstall the crate you can use a command similar to the install-command
 above.
 
@@ -29,6 +32,14 @@ above.
 # Uninstall the secret sharing tools
 cargo uninstall shamirsecretsharing-cli
 ```
+
+## macOS
+
+To install on macOS system, you can also use [Homebrew](https://brew.sh) package
+manager. The package is not yet in the upstream *homebrew-core*, but there exists a tap
+with **sss-cli** formula [here](https://github.com/vitkabele/homebrew-tap).
+
+To install using Homebrew, run: `brew install vitkabele/tap/sss-cli`.
 
 # F.A.Q.
 


### PR DESCRIPTION
I recently used this cli utility on macOS and because I didn't use the rust language before, I didn't have the cargo installation directory in my path.

And because I want all my installed software to be possibly managed by the same package manager, I added the `sss-cli` formula to my *homebrew-tap* to allow easier installation for others with the same issue.

I just modified the `README.md` to mention the alternative installation method.